### PR TITLE
Clear errors running with pandas v0.21.0

### DIFF
--- a/sample_cnn/data/mtt/build_mtt.py
+++ b/sample_cnn/data/mtt/build_mtt.py
@@ -98,7 +98,7 @@ def _process_dataset(anno, sample_rate, n_samples, n_threads):
     n_threads: Number of threads to process the dataset.
   """
   args_queue = Queue()
-  split_and_shard_sets = pd.unique(anno[['split', 'shard']].values)
+  split_and_shard_sets = pd.unique([tuple(x) for x in anno[['split', 'shard']].values])
 
   for split, shard in split_and_shard_sets:
     assigned_anno = anno[(anno['split'] == split) & (anno['shard'] == shard)]

--- a/sample_cnn/keras_utils/tfrecord_model.py
+++ b/sample_cnn/keras_utils/tfrecord_model.py
@@ -66,6 +66,7 @@ class TFRecordModel(Model):
     self.sample_weight_mode = None
     self.loss_weights = None
     self.y_val = y_val
+    self.constraints = None
 
     do_validation = bool(len(self.val_inputs) > 0)
     if do_validation and y_val is None:


### PR DESCRIPTION
1.  fix pd.unique issue under pandas v0.21.0
2.  fix self.constraints failed error

with python v3.6.3 / keras v2.0.9 / pandas v0.21.0